### PR TITLE
feat: clear prediction form

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -1,40 +1,45 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import TextField from "@mui/material/TextField";
 import Autocomplete from "@mui/material/Autocomplete";
 import { styled } from "@mui/material/styles";
+
+const StyledTextField = styled(TextField)({
+  "& label.Mui-disabled": {
+    color: "rgba(0, 0, 0, 1)", // (default alpha is 0.38)
+  },
+  "& label.Mui-focused": {
+    color: "#ad1457",
+  },
+  "& .MuiInput-underline:after": {
+    borderBottomColor: "#ad1457",
+  },
+  "& .MuiOutlinedInput-root": {
+    "& fieldset": {
+      borderColor: "#ad1457",
+    },
+    "&:hover fieldset": {
+      borderColor: "#ad1457",
+    },
+    "&.Mui-focused fieldset": {
+      borderColor: "#ad1457",
+    },
+  },
+});
 
 const Dropdown = ({
   options,
   onChange,
   label,
   defaultValue,
+  reset,
   multiple,
   disabled = false,
   sx = 300,
 }) => {
   const [value, setValue] = useState(defaultValue);
-  const StyledTextField = styled(TextField)({
-    "& label.Mui-disabled": {
-      color: "rgba(0, 0, 0, 1)", // (default alpha is 0.38)
-    },
-    "& label.Mui-focused": {
-      color: "#ad1457",
-    },
-    "& .MuiInput-underline:after": {
-      borderBottomColor: "#ad1457",
-    },
-    "& .MuiOutlinedInput-root": {
-      "& fieldset": {
-        borderColor: "#ad1457",
-      },
-      "&:hover fieldset": {
-        borderColor: "#ad1457",
-      },
-      "&.Mui-focused fieldset": {
-        borderColor: "#ad1457",
-      },
-    },
-  });
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [reset]);
 
   return (
     <Autocomplete

--- a/src/components/MUITextField/MUITextField.js
+++ b/src/components/MUITextField/MUITextField.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import { styled } from "@mui/material/styles";
@@ -34,10 +34,15 @@ const MUITextField = ({
   onChange,
   inputProps,
   type,
+  reset,
   disabled = false,
   width = "100%",
 }) => {
   const [value, setValue] = useState(defaultValue);
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [reset]);
+
   return (
     <StyledTextField
       fullWidth
@@ -82,9 +87,14 @@ export const MUITextFieldInterface = ({
   name,
   onChange,
   inputProps,
+  reset,
   type,
 }) => {
   const [value, setValue] = useState(defaultValue);
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [reset]);
+
   return (
     <StyledTextField
       fullWidth

--- a/src/components/PredictionForm/PredictionForm.css
+++ b/src/components/PredictionForm/PredictionForm.css
@@ -63,6 +63,12 @@
 
 .form-submit-button {
   padding-top: 3rem;
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  justify-content: center;
+  align-items: center;
+  width: 50%;
 }
 
 .output-area {

--- a/src/components/PredictionForm/PredictionForm.js
+++ b/src/components/PredictionForm/PredictionForm.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import WizardModelIdField from "../WizardModelIdField/WizardModelIdField";
 import Loader from "../Loader/Loader";
 import Button from "../Button/Button";
@@ -7,19 +7,19 @@ import RadioButtons from "../RadioButtons/RadioButtons";
 import Tooltip from "@mui/material/Tooltip";
 import TextField from "../MUITextField/MUITextField";
 import "./PredictionForm.css";
-import { Alert, Snackbar } from "@mui/material";
+import { Alert, Button as MUIButton, Snackbar } from "@mui/material";
 import { castPrediction } from "../../api/predictionsApi";
 import WizardPredictionOutput from "../WizardPredictionOutput/WizardPredictionOutput";
 
 // Replace the TextField component with the MUITextFieldInterface component
 // if updated TextField from ML-Measure breaks anything
-import { MUITextFieldInterface } from "../MUITextField/MUITextField";
 
 //TODO: Testing form with other models.
 const PredictionForm = ({ parsedConfig, modelId }) => {
   const [errorOpen, setErrorOpen] = useState(false);
-  const [formDataMap, setFormDataMap] = useState(new Map());
+  const [formDataMap, _] = useState(new Map());
   const [loading, setLoading] = useState(false);
+  const [reset, setReset] = useState(0);
   const [result, setResult] = useState(null);
 
   useEffect(() => {
@@ -28,6 +28,13 @@ const PredictionForm = ({ parsedConfig, modelId }) => {
       formDataMap.set(feature.name, feature.default_value);
     });
   }, []);
+
+  const onClearFormClicked = () => {
+    parsedConfig.features.forEach((feature) => {
+      formDataMap.set(feature.name, feature.default_value);
+    });
+    setReset((it) => it + 1);
+  };
 
   const onSubmitClicked = async () => {
     const values = Array.from(formDataMap.values());
@@ -105,6 +112,7 @@ const PredictionForm = ({ parsedConfig, modelId }) => {
                     helperText={feature.description}
                     defaultValue={feature.default_value}
                     name={feature.name}
+                    reset={reset}
                     key={feature.name}
                     onChange={(event) => {
                       onTextFieldChange(event, feature.name);
@@ -119,6 +127,7 @@ const PredictionForm = ({ parsedConfig, modelId }) => {
                     type="number"
                     key={feature.name}
                     name={feature.name}
+                    reset={reset}
                     onChange={(event) => {
                       onNumericTextFieldChange(event, feature.name);
                     }}
@@ -131,6 +140,7 @@ const PredictionForm = ({ parsedConfig, modelId }) => {
                       key={feature.name}
                       options={feature.values}
                       label={feature.name}
+                      reset={reset}
                       onChange={(event, newValue) => {
                         handleDropdownChange(event, newValue, feature.name);
                       }}
@@ -142,6 +152,7 @@ const PredictionForm = ({ parsedConfig, modelId }) => {
                       defaultValue={feature.default_value}
                       label={feature.name}
                       key={feature.name}
+                      reset={reset}
                       handleChange={(event, newValue) => {
                         handleRadioChange(event, feature.name);
                       }}
@@ -173,6 +184,14 @@ const PredictionForm = ({ parsedConfig, modelId }) => {
               text={loading ? <Loader type="tiny" /> : "Predict"}
               disabled={false}
             />
+            <MUIButton
+              variant="text"
+              onClick={() => {
+                onClearFormClicked();
+              }}
+            >
+              Clear Form
+            </MUIButton>
           </div>
           {result ? (
             <div className="output-area">

--- a/src/components/RadioButtons/RadioButtons.js
+++ b/src/components/RadioButtons/RadioButtons.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -11,10 +11,14 @@ const RadioButtons = ({
   handleChange,
   label,
   options,
+  reset,
   disabled = false,
   row = false,
 }) => {
-  const [value, setValue] = useState(defaultValue)
+  const [value, setValue] = useState(defaultValue);
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [reset]);
   return (
     <FormControl>
       <FormLabel
@@ -32,8 +36,8 @@ const RadioButtons = ({
         name="controlled-radio-buttons-group"
         value={value}
         onChange={(event, newValue) => {
-          handleChange(event, newValue)
-          setValue(newValue)
+          handleChange(event, newValue);
+          setValue(newValue);
         }}
         row={row}
       >


### PR DESCRIPTION
Clear form button added as discussed. Instead of refreshing the page, resets the fields based on a `reset` prop and `useEffect`. Order of values is preserved due to the backing `Map`, which is also reset when cleared.  